### PR TITLE
Add go-mode to packages

### DIFF
--- a/.config.org
+++ b/.config.org
@@ -525,6 +525,13 @@
   (use-package org-journal
     :ensure t)
 #+END_SRC
+** golang
+
+#+BEGIN_SRC emacs-lisp
+  (use-package go-mode
+    :ensure t)
+#+END_SRC
+
 * Miscellaneous
 ** Beautify org-mode
 

--- a/README.org
+++ b/README.org
@@ -77,4 +77,5 @@
   | select-themes           | Interactive theme selection.                             | [[https://melpa.org/#/select-themes][MELPA]]      |
   | browse-kill-ring        | Interactively insert items from kill ring.               | [[https://melpa.org/#/browse-kill-ring][MELPA]]      |
   | org-journal             | A simple org-mode based journaling mode.                 | [[https://melpa.org/#/org-journal][MELPA]]      |
+  | go-mode                 | Emacs mode for editing Go code                           | [[https://melpa.org/#/go-mode][MELPA]]      |
   


### PR DESCRIPTION
This commit adds the go-mode package to Emacs. Seeing as I've started using Go regularly even for non-DevOps stuff, I've decided to add it to my main config (master branch).